### PR TITLE
Changed save image path to user://

### DIFF
--- a/GUI/GUI.gd
+++ b/GUI/GUI.gd
@@ -170,7 +170,7 @@ func save_image(img):
 		var filesaver = get_tree().root.get_node("/root/HTML5File")
 		filesaver.save_image(img, String(sd))
 	else:
-		img.save_png("res://%s.png"%String(sd))
+		img.save_png("user://%s.png"%String(sd))
 
 func _on_ExportSpriteSheet_pressed():
 	$Panel.visible = false


### PR DESCRIPTION
Hey, 
Thank you for this wonderful project!

On MacOS, I couldn't save PNG files to disk. After checking the logs I found the following error:
> **ERROR**: Condition "err" is true. Returned: err
>   At: drivers/png/resource_saver_png.cpp:58:save_image() - Condition "err" is true. Returned: err

After poking around (never used Godot before) I found out that `res://` save path was the problem. It works when you run the app from the godot IDE, but once built, it seems the app runs in a read only environment. It is easily fixed by changing the path to `user://` and then files are being saved here (on mac):

```
~/Library/Application Support/Godot/PixelPlanets
```

According to [the documentation](https://docs.godotengine.org/en/stable/tutorials/io/data_paths.html) for windows and linux files should be saved here:
```
Windows: %APPDATA%\Godot\PixelPlanets
Linux: ~/.local/share/godot/PixelPlanets
```

Cheers!

P.S. I plan to use PixelPlanets with the pixel art frame I'm building (inspired by [this](https://ledseq.com/product/game-frame/)).
